### PR TITLE
Initial OSX without Lux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ PROJECT = radiance
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-	LINUX = true
-	CFLAGS = -DLINUX
+	__LINUX__ = true
+	CFLAGS = -D__LINUX__
 	RADIANCE_LUX = true
 endif
 ifeq ($(UNAME_S),Darwin)
-	OSX = true
-	CFLAGS = -DOSX -Wno-deprecated-declarations
+	__APPLE__ = true
+	CFLAGS = -Wno-deprecated-declarations
 endif
 
 # Source files
@@ -26,7 +26,7 @@ C_SRC += $(wildcard ui/*.c)
 C_SRC += $(filter-out util/opengl.c, $(wildcard util/*.c))
 C_SRC += $(wildcard BTrack/src/*.c)
 
-ifdef OSX
+ifdef __APPLE__
 	C_SRC += util/opengl.c
 endif
 
@@ -43,7 +43,7 @@ OBJECTS = $(C_SRC:%.c=$(OBJDIR)/%.o)
 INC = -I.
 
 LIBRARIES = -lSDL2 -lSDL2_ttf -lm -lportaudio -lportmidi -lfftw3 -lsamplerate
-ifdef LINUX
+ifdef __LINUX__
 	LIBRARIES += -lGL -lGLU
 else
 	LIBRARIES += -framework OpenGL

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,38 @@ PROJECT = radiance
 #CC = gcc
 #CC = clang
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LINUX = true
+	CFLAGS = -DLINUX
+	RADIANCE_LUX = true
+endif
+ifeq ($(UNAME_S),Darwin)
+	OSX = true
+	CFLAGS = -DOSX -Wno-deprecated-declarations
+endif
+
 # Source files
 C_SRC  = main.c
 C_SRC += $(wildcard audio/*.c)
 C_SRC += $(wildcard midi/*.c)
-C_SRC += $(wildcard output/*.c)
+# We'll add back output/lux.c later below if appropriate
+C_SRC += $(filter-out output/lux.c, $(wildcard output/*.c))
 C_SRC += $(wildcard pattern/*.c)
 C_SRC += $(wildcard time/*.c)
 C_SRC += $(wildcard ui/*.c)
-C_SRC += $(wildcard util/*.c)
-
-C_SRC += liblux/lux.c liblux/crc.c
+# We'll add back util/opengl.c later below if appropriate
+C_SRC += $(filter-out util/opengl.c, $(wildcard util/*.c))
 C_SRC += $(wildcard BTrack/src/*.c)
+
+ifdef OSX
+	C_SRC += util/opengl.c
+endif
+
+ifdef RADIANCE_LUX
+	C_SRC += output/lux.c
+	C_SRC += liblux/lux.c liblux/crc.c
+endif
 
 OBJDIR = build
 $(shell mkdir -p $(OBJDIR) >/dev/null)
@@ -22,9 +42,14 @@ OBJECTS = $(C_SRC:%.c=$(OBJDIR)/%.o)
 # Compiler flags
 INC = -I.
 
-LIBRARIES = -lSDL2 -lSDL2_ttf -lGL -lGLU -lm -lportaudio -lportmidi -lfftw3 -lsamplerate
+LIBRARIES = -lSDL2 -lSDL2_ttf -lm -lportaudio -lportmidi -lfftw3 -lsamplerate
+ifdef LINUX
+	LIBRARIES += -lGL -lGLU
+else
+	LIBRARIES += -framework OpenGL
+endif
 
-CFLAGS = -std=c99 -ggdb3 -O3 $(INC)
+CFLAGS += -std=c99 -ggdb3 -O3 $(INC)
 CFLAGS += -Wall -Wextra -Werror -Wno-unused-parameter
 CFLAGS += -D_POSIX_C_SOURCE=20160524
 LFLAGS = $(CFLAGS)
@@ -50,12 +75,16 @@ $(OBJDIR)/%.o: %.c
 luxctl: $(OBJDIR)/luxctl.o $(OBJDIR)/liblux/lux.o $(OBJDIR)/liblux/crc.o
 	$(CC) $(LFLAGS) -o $@ $^ 
 
+ifdef RADIANCE_LUX
+	MAYBE_LUXCTL = luxctl
+endif
+
 .PHONY: all
-all: $(PROJECT) luxctl
+all: $(PROJECT) $(MAYBE_LUXCTL)
 
 .PHONY: clean
 clean:
-	-rm -f $(PROJECT) tags luxctl
+	-rm -f $(PROJECT) tags $(MAYBE_LUXCTL)
 	-rm -rf $(OBJDIR) $(DEPDIR)
 
 tags: $(C_SRC)

--- a/pattern/crossfader.c
+++ b/pattern/crossfader.c
@@ -18,7 +18,7 @@ void crossfader_init(struct crossfader * crossfader) {
     // Render targets
     glGenFramebuffersEXT(1, &crossfader->fb);
     glGenTextures(1, &crossfader->tex_output);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindTexture(GL_TEXTURE_2D, crossfader->tex_output);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -28,14 +28,14 @@ void crossfader_init(struct crossfader * crossfader) {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, config.pattern.master_width, config.pattern.master_height, 0, 
                  GL_RGBA, GL_UNSIGNED_BYTE, NULL);
     glBindTexture(GL_TEXTURE_2D, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, crossfader->fb);
     glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D,
                               crossfader->tex_output, 0);
     glClear(GL_COLOR_BUFFER_BIT);
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 }
 
 void crossfader_term(struct crossfader * crossfader) {
@@ -44,7 +44,7 @@ void crossfader_term(struct crossfader * crossfader) {
     glDeleteTextures(1, &crossfader->tex_output);
     glDeleteFramebuffersEXT(1, &crossfader->fb);
     glDeleteObjectARB(crossfader->shader);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     memset(crossfader, 0, sizeof *crossfader);
 }
@@ -60,7 +60,7 @@ void crossfader_render(struct crossfader * crossfader, GLuint left, GLuint right
     glBindTexture(GL_TEXTURE_2D, left);
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, right);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     GLint loc;
     loc = glGetUniformLocationARB(crossfader->shader, "iResolution");
@@ -73,7 +73,7 @@ void crossfader_render(struct crossfader * crossfader, GLuint left, GLuint right
     glUniform1iARB(loc, 1);
     loc = glGetUniformLocationARB(crossfader->shader, "iLeftOnTop");
     glUniform1iARB(loc, crossfader->left_on_top);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glClear(GL_COLOR_BUFFER_BIT);
     glBegin(GL_QUADS);
@@ -84,7 +84,7 @@ void crossfader_render(struct crossfader * crossfader, GLuint left, GLuint right
     glEnd();
 
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     if(crossfader->position == 1.) {
         crossfader->left_on_top = true;

--- a/pattern/crossfader.h
+++ b/pattern/crossfader.h
@@ -2,7 +2,7 @@
 
 #define GL_GLEXT_PROTOTYPES
 #include <SDL2/SDL_opengl.h>
-#include <GL/glu.h>
+#include "util/opengl.h"
 #include <stdbool.h>
 #include "pattern/deck.h"
 

--- a/pattern/deck.c
+++ b/pattern/deck.c
@@ -19,7 +19,7 @@ void deck_init(struct deck * deck) {
 
     glGenTextures(1, &deck->tex_input);
     glGenFramebuffersEXT(1, &deck->fb_input);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindTexture(GL_TEXTURE_2D, deck->tex_input);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -28,7 +28,7 @@ void deck_init(struct deck * deck) {
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, config.pattern.master_width, config.pattern.master_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
     glBindTexture(GL_TEXTURE_2D, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, deck->fb_input);
     glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D,
@@ -36,7 +36,7 @@ void deck_init(struct deck * deck) {
     glClear(GL_COLOR_BUFFER_BIT);
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 }
 
 void deck_term(struct deck * deck) {

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -77,13 +77,13 @@ int pattern_init(struct pattern * pattern, const char * prefix) {
         return 2;
     }
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     // Render targets
     glGenFramebuffersEXT(1, &pattern->fb);
     glGenTextures(pattern->n_shaders + 1, pattern->tex);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     for(int i = 0; i < pattern->n_shaders + 1; i++) {
         glBindTexture(GL_TEXTURE_2D, pattern->tex[i]);
@@ -96,7 +96,7 @@ int pattern_init(struct pattern * pattern, const char * prefix) {
     }
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, pattern->fb);
     for(int i = 0; i < pattern->n_shaders + 1; i++) {
@@ -105,7 +105,7 @@ int pattern_init(struct pattern * pattern, const char * prefix) {
         glClear(GL_COLOR_BUFFER_BIT);
     }
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     // Some OpenGL API garbage
     pattern->uni_tex = calloc(pattern->n_shaders, sizeof *pattern->uni_tex);
@@ -127,7 +127,7 @@ void pattern_term(struct pattern * pattern) {
     glDeleteTextures(pattern->n_shaders + 1, pattern->tex);
     glDeleteFramebuffersEXT(1, &pattern->fb);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     free(pattern->name);
     memset(pattern, 0, sizeof *pattern);
@@ -154,7 +154,7 @@ void pattern_render(struct pattern * pattern, GLuint input_tex) {
         glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D,
                                   pattern->tex[(pattern->flip + i + 1) % (pattern->n_shaders + 1)], 0);
 
-        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
         GLint loc;
         loc = glGetUniformLocationARB(pattern->shader[i], "iTime");
@@ -183,7 +183,7 @@ void pattern_render(struct pattern * pattern, GLuint input_tex) {
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, input_tex);
 
-        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
         glClear(GL_COLOR_BUFFER_BIT);
         glBegin(GL_QUADS);
@@ -193,11 +193,11 @@ void pattern_render(struct pattern * pattern, GLuint input_tex) {
         glVertex2d(1, -1);
         glEnd();
 
-        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
     }
     pattern->flip = (pattern->flip + 1) % (pattern->n_shaders + 1);
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
     pattern->tex_output = pattern->tex[pattern->flip];
 }

--- a/pattern/pattern.h
+++ b/pattern/pattern.h
@@ -2,7 +2,7 @@
 
 #define GL_GLEXT_PROTOTYPES
 #include <SDL2/SDL_opengl.h>
-#include <GL/glu.h>
+#include "util/opengl.h"
 #include <stdbool.h>
 
 #define MAX_INTEGRAL 1024

--- a/time/timebase.c
+++ b/time/timebase.c
@@ -5,9 +5,8 @@
 #include "util/err.h"
 #include "util/math.h"
 
-#ifdef OSX
-    #include <mach/clock.h>
-    #include <mach/mach.h>
+#ifdef __APPLE__
+    #include <mach/mach_time.h>
 #endif
 
 #include "time/timebase.h"
@@ -16,6 +15,10 @@
 
 struct time_master time_master;
 double phase = 0.0;
+
+#ifdef __APPLE__
+    double time_conversion_factor;
+#endif
 
 // Maximum size of `time_master.beat_index`. 16 to track 4/4 beats+bars
 //static uint8_t master_beat_denominator = 16;
@@ -46,6 +49,13 @@ int time_init() {
     memset(&time_master, 0, sizeof time_master);
     time_master.bpm = 140;
     error_wrap_test();
+
+    #ifdef __APPLE__
+        mach_timebase_info_data_t timebase;
+        mach_timebase_info(&timebase);
+        time_conversion_factor = (double)timebase.numer / (double)timebase.denom;
+    #endif
+
     return 0;
 }
 
@@ -56,19 +66,15 @@ void time_term() {
 void time_update(enum time_source source, enum time_source_event event, double event_arg) {
     struct timespec tv = {0, 0};
 
-    #ifdef LINUX
+    #ifdef __LINUX__
         if (clock_gettime(CLOCK_MONOTONIC_RAW, &tv) != 0) {
             PERROR("clock_gettime failed");
             return;
         }
-    #elif OSX
-        clock_serv_t cclock;
-        mach_timespec_t mts;
-        host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-        clock_get_time(cclock, &mts);
-        mach_port_deallocate(mach_task_self(), cclock);
-        tv.tv_sec = mts.tv_sec;
-        tv.tv_nsec = mts.tv_nsec;
+    #elif __APPLE__
+        uint64_t time = mach_absolute_time();
+        tv.tv_nsec = ((double)time) * time_conversion_factor;
+        tv.tv_sec = ((double)time) * time_conversion_factor / 1e9;
     #endif
 
     // Convert to milliseconds

--- a/ui/render.c
+++ b/ui/render.c
@@ -13,12 +13,12 @@ void render_init(struct render * render, GLint texture) {
     if(render->pixels == NULL) MEMFAIL();
 
     glGenFramebuffersEXT(1, &render->fb);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, render->fb);
     glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, texture, 0);
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     render->mutex = SDL_CreateMutex();
     if(render->mutex == NULL) FAIL("Could not create mutex: %s\n", SDL_GetError());
@@ -39,7 +39,7 @@ void render_readback(struct render * render) {
         glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
         glReadPixels(0, 0, config.pattern.master_width, config.pattern.master_height, GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)render->pixels);
         glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+        if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
         SDL_UnlockMutex(render->mutex);
     }
 }

--- a/ui/render.h
+++ b/ui/render.h
@@ -2,7 +2,7 @@
 
 #define GL_GLEXT_PROTOTYPES
 #include <SDL2/SDL_opengl.h>
-#include <GL/glu.h>
+#include "util/opengl.h"
 #include <stdint.h>
 #include <SDL2/SDL.h>
 

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -17,7 +17,7 @@
 #include "main.h"
 #include <stdio.h>
 #include <stdbool.h>
-#include <GL/glu.h>
+#include "util/opengl.h"
 
 static SDL_Window * window;
 static SDL_GLContext context;
@@ -187,8 +187,8 @@ void ui_init() {
     // Init SDL
     if(SDL_Init(SDL_INIT_VIDEO) < 0) FAIL("SDL could not initialize! SDL Error: %s\n", SDL_GetError());
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
     ww = config.ui.window_width;
     wh = config.ui.window_height;
@@ -209,7 +209,20 @@ void ui_init() {
     glMatrixMode(GL_MODELVIEW);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glClearColor(0, 0, 0, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+
+    // OpenGL starts with GL_INVALID_OPERATION set.  Typically this is cleared by creating a context,
+    // but this doesn't seem to be getting cleared properly on OS X.  I'm guessing this is because
+    // SDL_GL_CreateContext (which is from a different library) isn't clearing it properly.  It doesn't
+    // seem to have any ill affect on operation, and in any event all of the OpenGL UI is getting blown
+    // away soon in favor of Qt.
+    e = glGetError();
+    #ifdef OSX
+        if ((e != GL_NO_ERROR) && (e != GL_INVALID_OPERATION)) {
+    #else
+        if (e != GL_NO_ERROR) {
+    #endif
+        FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
+    }
 
     // Make framebuffers
     glGenFramebuffersEXT(1, &select_fb);
@@ -219,7 +232,7 @@ void ui_init() {
     glGenFramebuffersEXT(1, &spectrum_fb);
     glGenFramebuffersEXT(1, &waveform_fb);
     glGenFramebuffersEXT(1, &strip_fb);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     // Init select texture
     glGenTextures(1, &select_tex);
@@ -242,7 +255,7 @@ void ui_init() {
     pattern_name_height = calloc(config.ui.n_patterns, sizeof(int));
     if(pattern_name_textures == NULL || pattern_name_width == NULL || pattern_name_height == NULL) MEMFAIL();
     glGenTextures(config.ui.n_patterns, pattern_textures);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
     for(int i = 0; i < config.ui.n_patterns; i++) {
         glBindTexture(GL_TEXTURE_2D, pattern_textures[i]);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -336,7 +349,7 @@ void ui_init() {
     // Done allocating textures & FBOs, unbind and check for errors
     glBindTexture(GL_TEXTURE_2D, 0);
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 
     if((blit_shader = load_shader("resources/blit.glsl")) == 0) FAIL("Could not load blit shader!\n%s", load_shader_error);
     if((main_shader = load_shader("resources/ui_main.glsl")) == 0) FAIL("Could not load UI main shader!\n%s", load_shader_error);
@@ -921,7 +934,7 @@ static void ui_render(bool select) {
 
     glDisable(GL_BLEND);
 
-    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", gluErrorString(e));
+    if((e = glGetError()) != GL_NO_ERROR) FAIL("OpenGL error: %s\n", GLU_ERROR_STRING(e));
 }
 
 struct rgba {

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -216,7 +216,7 @@ void ui_init() {
     // seem to have any ill affect on operation, and in any event all of the OpenGL UI is getting blown
     // away soon in favor of Qt.
     e = glGetError();
-    #ifdef OSX
+    #ifdef __APPLE__
         if ((e != GL_NO_ERROR) && (e != GL_INVALID_OPERATION)) {
     #else
         if (e != GL_NO_ERROR) {

--- a/util/opengl.c
+++ b/util/opengl.c
@@ -1,0 +1,15 @@
+#include "opengl.h"
+
+const char* osxGluErrorString(GLenum error) {
+    switch (error) {
+        case GL_INVALID_ENUM: return "invalid enumerant";
+        case GL_INVALID_VALUE: return "invalid value";
+        case GL_INVALID_OPERATION: return "invalid operation";
+        case GL_STACK_OVERFLOW: return "stack overflow";
+        case GL_STACK_UNDERFLOW: return "stack underflow";
+        case GL_OUT_OF_MEMORY: return "out of memory";
+        case GL_TABLE_TOO_LARGE: return "table too large";
+        case GL_INVALID_FRAMEBUFFER_OPERATION: return "invalid framebuffer operation";
+        default: return "unknown GL error";
+     }
+}

--- a/util/opengl.h
+++ b/util/opengl.h
@@ -1,12 +1,12 @@
-#ifdef LINUX
+#ifdef __LINUX__
     #include <GL/glu.h>
-#elif OSX
+#elif __APPLE__
     #include <OpenGL/glu.h>
 #endif
 
-#ifdef LINUX
+#ifdef __LINUX__
     #define GLU_ERROR_STRING(e) gluErrorString(e)
-#elif OSX
+#elif __APPLE__
     const char* osxGluErrorString(GLenum error);
     #define GLU_ERROR_STRING(e) osxGluErrorString(e)
 #endif

--- a/util/opengl.h
+++ b/util/opengl.h
@@ -1,0 +1,12 @@
+#ifdef LINUX
+    #include <GL/glu.h>
+#elif OSX
+    #include <OpenGL/glu.h>
+#endif
+
+#ifdef LINUX
+    #define GLU_ERROR_STRING(e) gluErrorString(e)
+#elif OSX
+    const char* osxGluErrorString(GLenum error);
+    #define GLU_ERROR_STRING(e) osxGluErrorString(e)
+#endif


### PR DESCRIPTION
Simple port to Mac OS X.  Everything works except the Lux backend.  Special thanks to @maxbeeman for giving me a couple hours on her dev machine.

I'm not compiling Lux here because it makes use of `epoll` which OS X doesn't have.  There are obviously replacements for `epoll`, but given that 1E doesn't use Lux and I don't actually have a Lux device to test against I don't really want to try including it this time around.  Having said that, everything else does work, so this will run fine on the 1E dancefloor.  It'll also probably be nice in the future to choose which backends to compile, and this does some of the work for that.

This is my first time I've had to set up an infrastructure to deal with multiple platforms, so please yell at me aggressively for bad Makefile organization, non-standard naming, etc.

1E people, I'm about to email 1e-dancefloor@; if no one comments in a couple days I'll go ahead and merge it because it'll make development nicer for Mac users and we already have a few too many branches rebased on branches rebased on branches.  If you end up having comments after I do so please comment anyway and I'll make another PR to respond.